### PR TITLE
Generate Duty Cycle Generator from Servo Angle to Microseconds

### DIFF
--- a/pi/platform_controller.py
+++ b/pi/platform_controller.py
@@ -7,13 +7,22 @@ import numpy as np
 
 
 class PlatformController:
-    def __init__(self, duty_cycle_min, duty_cycle_max, port, baudrate=9600, debug: bool = False):
+    def __init__(
+        self,
+        port,
+        baudrate=9600,
+        duty_cycle_min=500,
+        duty_cycle_max=2300,
+        debug: bool = False,
+    ):
         # Min and max duty cycles translate to 0 to 180 degrees on the servo
         # gathered from empirical data primarily
-        self.duty_cycle_min = duty_cycle_min
-        self.duty_cycle_max = duty_cycle_max
         self.port = port
         self.ser = serial.Serial(port, baudrate)
+
+        self.duty_cycle_min = duty_cycle_min
+        self.duty_cycle_max = duty_cycle_max
+
         self.debug = debug
 
     def write_raw(self, data: bytearray):
@@ -25,7 +34,9 @@ class PlatformController:
         # Map the desired angle between 0 to pi, and map that value to the
         # duty cycle based on min and max duty cycles
         percentage = servo_angle / np.pi
-        duty_cycle = self.duty_cycle_min + percentage * (self.duty_cycle_max - self.duty_cycle_min)
+        duty_cycle = self.duty_cycle_min + percentage * (
+            self.duty_cycle_max - self.duty_cycle_min
+        )
         return duty_cycle
 
     def write_duty_cycles(self, duty_cycle_1, duty_cycle_2, duty_cycle_3):

--- a/pi/servo_kinematics_module.py
+++ b/pi/servo_kinematics_module.py
@@ -58,7 +58,7 @@ class ServoKinematicsModule:
         theta1_solution, theta2_solution = result.x
 
         return theta1_solution, theta2_solution
-    
+
     def visualize_linkage(self, theta1, theta2, ax):
         """
         Visualizes the 2D linkage of the servo and arm system using forward kinematics.

--- a/pi/tests/test_platform_controller.py
+++ b/pi/tests/test_platform_controller.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import numpy as np
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
 
@@ -48,3 +49,20 @@ def test_platform_controller_write_duty_cycles_encoded():
     bytes.extend(dutycycle_3_bytes)
 
     assert os.read(fakeser[1], 6) == bytes
+
+
+def test_duty_cycle_resolver_from_angle():
+    fakeser = create_fake_serial()
+    pc = platform_controller.PlatformController(fakeser[0])
+
+    angle_ninety_degrees_duty_cycle = pc.compute_duty_cycle_from_angle(np.pi / 2)
+
+    assert angle_ninety_degrees_duty_cycle == 1400
+
+    angle_zero_duty_cycle = pc.compute_duty_cycle_from_angle(0)
+
+    assert angle_zero_duty_cycle == 500
+
+    angle_full_duty_cycle = pc.compute_duty_cycle_from_angle(np.pi)
+
+    assert angle_full_duty_cycle == 2300


### PR DESCRIPTION
## Generate Duty Cycle Generator from Servo Angle to Microseconds

Created a function within `platform_controller.py` to allow for the desired servo angle to be converted to actual servo movement

Created tests for three points, validated by running them

Found 0 and PI radian values in microseconds using empirical testing on given servos