### PR TITLE
Angle Offsets for Servos to tune IK

### DIFF
--- a/pi/main.py
+++ b/pi/main.py
@@ -9,14 +9,14 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
 import time
 
+# Current computed offsets are [0, 8, 10] for servo 0, 1, and 2 respectively
+
 
 class MainControlLoop:
     def __init__(
         self,
         serial_port: str,
-        servo_0_offset: float = 0,
-        servo_1_offset: float = 8,
-        servo_2_offset: float = 10,
+        servo_offsets: list[float] = [0, 0, 0],  # degrees
         virtual: bool = False,
         run_visualizer: bool = False,
         run_controller: bool = False,
@@ -27,7 +27,11 @@ class MainControlLoop:
             "platform_attachment_radius": 100 / 1000,
         }
 
-        self.servo_offset_radians = [np.radians(servo_0_offset), np.radians(servo_1_offset), np.radians(servo_2_offset)]
+        self.servo_offset_radians = [
+            np.radians(servo_offsets[0]),
+            np.radians(servo_offsets[1]),
+            np.radians(servo_offsets[2]),
+        ]
 
         attachment_points_structure = [
             [1.0, 0.0, 0.0],
@@ -95,7 +99,9 @@ class MainControlLoop:
                 desired_servo_length = np.linalg.norm(servo_vectors[i])
                 servo_angle = self.sk.compute_servo_angle(desired_servo_length)
                 servo_angles.append(servo_angle)
-                duty_cycle = self.pc.compute_duty_cycle_from_angle(servo_angle[0] + self.servo_offset_radians[i])
+                duty_cycle = self.pc.compute_duty_cycle_from_angle(
+                    servo_angle[0] + self.servo_offset_radians[i]
+                )
                 duty_cycles.append(duty_cycle)
 
             # Send the servo angles to the platform


### PR DESCRIPTION
Some of the servos have an offset, where the servos are slightly less/greater than the desired angle by a decently constant value.

Adding an offset will fix that

Currently, these are added via main.py, but would be nice to eventually have them via the IK controller itself. That needs some more refactoring however so in the interest of time it is only implemented in main.py right now